### PR TITLE
Update section about augmenting official Azure CLI Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,21 +167,17 @@ FROM mcr.microsoft.com/azure-cli:latest
 ENV PATH="/venv/bin:${PATH}"
 
 RUN : \
-    && python3 -m venv /venv \
+    && python3 -m venv --system-site-packages /venv \
     && pip install --disable-pip-version-check --no-cache-dir --no-dependencies az.cli
-
-ENV PYTHONPATH="/usr/local/lib/python3.8/site-packages"
 ```
 
 What that does is:
 
 - adds the virtual environment directory to the `PATH` environment variable
+- creates a virtual environment with access to the system `site-packages` directory
+  - this is what `--system-site-packages` does
 - installs this project into that virtual environment _without_ installing dependencies
   - as they are already in the original image
   - this is what `--no-dependencies` does
-- sets the `PYTHONPATH` environment variable to the equal the path at which the already included Azure CLI modules exist
-  - it's added at the end as opposed to the first `ENV` line to avoid overriding the path at which this project is installed at
 
 The `--disable-pip-version-check` option is set as it offers no tangible benefit to check Pip's version when building. The same goes for `--no-cache-dir` as the resulting image will be smaller due to Pip not having cached anything.
-
-It's not possible, [that I know of](https://github.com/moby/moby/issues/29110) to set this dynamically, so this needs to be validated against the version of Python used in [their Dockerfile](https://github.com/Azure/azure-cli/blob/dev/Dockerfile).


### PR DESCRIPTION
I recently stumbled across the `--system-site-packages` option for the `venv` module in Python, which to me seems like a a much better way of achieving what I had done before, so I wanted to amend my short write-up to better represent best practices.